### PR TITLE
Add model dropdowns with known models and French translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,11 @@ None
 
 ## Change log
 
+* **1.0.5 (2026031600)**
+    - Model fields now use autocomplete dropdowns with known models per provider (with free-text input for custom models).
+    - Updated OpenAI models list: added gpt-5.4, gpt-5, gpt-image-1.5, gpt-4o-transcribe-diarize, etc.
+    - Updated Mistral models list: added mistral-large-3-25-12, magistral-*, devstral-*, voxtral-*, codestral-embed-25-05.
+    - Added French translation (lang/fr/local_mxaimanager.php).
 * **1.0.4 (2026011200)**
     - Added support for AI usage logging.
     - Added support for AI image generation.

--- a/classes/app/ai/provider/providers/mistral.php
+++ b/classes/app/ai/provider/providers/mistral.php
@@ -49,50 +49,41 @@ class mistral extends provider implements interfaces\chat_completion, interfaces
         ]);
     }
 
+    private const CHAT_MODELS = [
+        'mistral-large-3-25-12', 'mistral-medium-3-1-25-08', 'mistral-small-3-2-25-06',
+        'ministral-3-14b-25-12', 'ministral-3-8b-25-12', 'ministral-3-3b-25-12',
+        'magistral-medium-1-2-25-09', 'magistral-small-1-2-25-09',
+        'devstral-2-25-12', 'codestral-25-08',
+    ];
+
+    private const EMBEDDING_MODELS = [
+        'mistral-embed-23-12', 'codestral-embed-25-05',
+    ];
+
+    private const TRANSCRIPTION_MODELS = [
+        'voxtral-mini-transcribe-26-02', 'voxtral-mini-transcribe-25-07',
+        'voxtral-mini-25-07', 'voxtral-small-25-07',
+    ];
+
     private static function add_chat_model_field(\MoodleQuickForm $mform, string $element_name_prefix): void
     {
-        $mform->addElement(
-            'text',
-            "{$element_name_prefix}chat_model",
-            get_string('default_chat_model', 'local_mxaimanager'),
-            [
-                'action' => interfaces\chat_completion::class
-            ]
-        );
-        $mform->setType("{$element_name_prefix}chat_model", PARAM_TEXT);
-        $mform->addHelpButton("{$element_name_prefix}chat_model", 'mistral_chat_model', 'local_mxaimanager');
+        self::add_model_field($mform, $element_name_prefix, 'chat_model',
+            'default_chat_model', 'mistral_chat_model',
+            interfaces\chat_completion::class, self::CHAT_MODELS);
     }
 
     private static function add_embedding_model_field(\MoodleQuickForm $mform, string $element_name_prefix): void
     {
-        $mform->addElement(
-            'text',
-            "{$element_name_prefix}embedding_model",
-            get_string('default_embedding_model', 'local_mxaimanager'),
-            [
-                'action' => interfaces\create_embedding::class
-            ]
-        );
-        $mform->setType("{$element_name_prefix}embedding_model", PARAM_TEXT);
-        $mform->addHelpButton("{$element_name_prefix}embedding_model", 'mistral_embedding_model', 'local_mxaimanager');
+        self::add_model_field($mform, $element_name_prefix, 'embedding_model',
+            'default_embedding_model', 'mistral_embedding_model',
+            interfaces\create_embedding::class, self::EMBEDDING_MODELS);
     }
 
     private static function add_transcription_model_field(\MoodleQuickForm $mform, string $element_name_prefix): void
     {
-        $mform->addElement(
-            'text',
-            "{$element_name_prefix}transcription_model",
-            get_string('default_transcription_model', 'local_mxaimanager'),
-            [
-                'action' => interfaces\create_transcription::class
-            ]
-        );
-        $mform->setType("{$element_name_prefix}transcription_model", PARAM_TEXT);
-        $mform->addHelpButton(
-            "{$element_name_prefix}transcription_model",
-            'mistral_transcription_model',
-            'local_mxaimanager'
-        );
+        self::add_model_field($mform, $element_name_prefix, 'transcription_model',
+            'default_transcription_model', 'mistral_transcription_model',
+            interfaces\create_transcription::class, self::TRANSCRIPTION_MODELS);
     }
 
     public static function moodleform_definition(\MoodleQuickForm $mform, string $element_name_prefix): void

--- a/classes/app/ai/provider/providers/nebius.php
+++ b/classes/app/ai/provider/providers/nebius.php
@@ -48,46 +48,39 @@ class nebius extends provider implements interfaces\chat_completion, interfaces\
         ]);
     }
 
+    private const CHAT_MODELS = [
+        'meta-llama/Meta-Llama-3.1-70B-Instruct', 'meta-llama/Meta-Llama-3.1-8B-Instruct',
+        'Qwen/Qwen2.5-72B-Instruct', 'deepseek-ai/DeepSeek-V3',
+        'mistralai/Mistral-Nemo-Instruct-2407',
+    ];
+
+    private const EMBEDDING_MODELS = [
+        'BAAI/bge-en-icl', 'intfloat/multilingual-e5-large-instruct', 'BAAI/bge-m3',
+    ];
+
+    private const IMAGE_MODELS = [
+        'black-forest-labs/FLUX.1-schnell', 'stability-ai/sdxl',
+    ];
+
     private static function add_chat_model_field(\MoodleQuickForm $mform, string $element_name_prefix): void
     {
-        $mform->addElement(
-            'text',
-            "{$element_name_prefix}chat_model",
-            get_string('default_chat_model', 'local_mxaimanager'),
-            [
-                'action' => interfaces\chat_completion::class
-            ]
-        );
-        $mform->setType("{$element_name_prefix}chat_model", PARAM_TEXT);
-        $mform->addHelpButton("{$element_name_prefix}chat_model", 'nebius_chat_model', 'local_mxaimanager');
+        self::add_model_field($mform, $element_name_prefix, 'chat_model',
+            'default_chat_model', 'nebius_chat_model',
+            interfaces\chat_completion::class, self::CHAT_MODELS);
     }
 
     private static function add_embedding_model_field(\MoodleQuickForm $mform, string $element_name_prefix): void
     {
-        $mform->addElement(
-            'text',
-            "{$element_name_prefix}embedding_model",
-            get_string('default_embedding_model', 'local_mxaimanager'),
-            [
-                'action' => interfaces\create_embedding::class
-            ]
-        );
-        $mform->setType("{$element_name_prefix}embedding_model", PARAM_TEXT);
-        $mform->addHelpButton("{$element_name_prefix}embedding_model", 'nebius_embedding_model', 'local_mxaimanager');
+        self::add_model_field($mform, $element_name_prefix, 'embedding_model',
+            'default_embedding_model', 'nebius_embedding_model',
+            interfaces\create_embedding::class, self::EMBEDDING_MODELS);
     }
 
     private static function add_image_model_field(\MoodleQuickForm $mform, string $element_name_prefix): void
     {
-        $mform->addElement(
-            'text',
-            "{$element_name_prefix}image_model",
-            get_string('default_image_model', 'local_mxaimanager'),
-            [
-                'action' => interfaces\create_image::class
-            ]
-        );
-        $mform->setType("{$element_name_prefix}image_model", PARAM_TEXT);
-        $mform->addHelpButton("{$element_name_prefix}image_model", 'nebius_image_model', 'local_mxaimanager');
+        self::add_model_field($mform, $element_name_prefix, 'image_model',
+            'default_image_model', 'nebius_image_model',
+            interfaces\create_image::class, self::IMAGE_MODELS);
     }
 
     public static function moodleform_definition(\MoodleQuickForm $mform, string $element_name_prefix): void

--- a/classes/app/ai/provider/providers/ollama.php
+++ b/classes/app/ai/provider/providers/ollama.php
@@ -44,32 +44,27 @@ class ollama extends provider implements interfaces\chat_completion, interfaces\
         ]);
     }
 
+    private const CHAT_MODELS = [
+        'llama3.1', 'llama3', 'llama3.2', 'mistral', 'phi3', 'gemma2',
+        'codellama', 'qwen2', 'deepseek-r1',
+    ];
+
+    private const EMBEDDING_MODELS = [
+        'nomic-embed-text', 'mxbai-embed-large', 'all-minilm', 'snowflake-arctic-embed',
+    ];
+
     private static function add_chat_model_field(\MoodleQuickForm $mform, string $element_name_prefix): void
     {
-        $mform->addElement(
-            'text',
-            "{$element_name_prefix}chat_model",
-            get_string('default_chat_model', 'local_mxaimanager'),
-            [
-                'action' => interfaces\chat_completion::class
-            ]
-        );
-        $mform->setType("{$element_name_prefix}chat_model", PARAM_TEXT);
-        $mform->addHelpButton("{$element_name_prefix}chat_model", 'ollama_chat_model', 'local_mxaimanager');
+        self::add_model_field($mform, $element_name_prefix, 'chat_model',
+            'default_chat_model', 'ollama_chat_model',
+            interfaces\chat_completion::class, self::CHAT_MODELS);
     }
 
     private static function add_embedding_model_field(\MoodleQuickForm $mform, string $element_name_prefix): void
     {
-        $mform->addElement(
-            'text',
-            "{$element_name_prefix}embedding_model",
-            get_string('default_embedding_model', 'local_mxaimanager'),
-            [
-                'action' => interfaces\create_embedding::class
-            ]
-        );
-        $mform->setType("{$element_name_prefix}embedding_model", PARAM_TEXT);
-        $mform->addHelpButton("{$element_name_prefix}embedding_model", 'ollama_embedding_model', 'local_mxaimanager');
+        self::add_model_field($mform, $element_name_prefix, 'embedding_model',
+            'default_embedding_model', 'ollama_embedding_model',
+            interfaces\create_embedding::class, self::EMBEDDING_MODELS);
     }
 
     public static function moodleform_definition(\MoodleQuickForm $mform, string $element_name_prefix): void

--- a/classes/app/ai/provider/providers/openai.php
+++ b/classes/app/ai/provider/providers/openai.php
@@ -52,64 +52,53 @@ class openai extends provider implements interfaces\chat_completion, interfaces\
         ]);
     }
 
+    private const CHAT_MODELS = [
+        'gpt-5.4', 'gpt-5.4-pro', 'gpt-5', 'gpt-5-mini', 'gpt-5-nano',
+        'gpt-4.1', 'gpt-4.1-mini', 'gpt-4.1-nano',
+        'gpt-4o', 'gpt-4o-mini',
+        'o3', 'o3-mini', 'o3-pro',
+    ];
+
+    private const EMBEDDING_MODELS = [
+        'text-embedding-3-large', 'text-embedding-3-small', 'text-embedding-ada-002',
+    ];
+
+    private const IMAGE_MODELS = [
+        'gpt-image-1.5', 'gpt-image-1', 'gpt-image-1-mini',
+        'dall-e-3', 'dall-e-2',
+    ];
+
+    private const TRANSCRIPTION_MODELS = [
+        'gpt-4o-transcribe', 'gpt-4o-mini-transcribe',
+        'gpt-4o-transcribe-diarize', 'whisper-1',
+    ];
+
     private static function add_chat_model_field(\MoodleQuickForm $mform, string $element_name_prefix): void
     {
-        $mform->addElement(
-            'text',
-            "{$element_name_prefix}chat_model",
-            get_string('default_chat_model', 'local_mxaimanager'),
-            [
-                'action' => interfaces\chat_completion::class
-            ]
-        );
-        $mform->setType("{$element_name_prefix}chat_model", PARAM_TEXT);
-        $mform->addHelpButton("{$element_name_prefix}chat_model", 'openai_chat_model', 'local_mxaimanager');
+        self::add_model_field($mform, $element_name_prefix, 'chat_model',
+            'default_chat_model', 'openai_chat_model',
+            interfaces\chat_completion::class, self::CHAT_MODELS);
     }
 
     private static function add_embedding_model_field(\MoodleQuickForm $mform, string $element_name_prefix): void
     {
-        $mform->addElement(
-            'text',
-            "{$element_name_prefix}embedding_model",
-            get_string('default_embedding_model', 'local_mxaimanager'),
-            [
-                'action' => interfaces\create_embedding::class
-            ]
-        );
-        $mform->setType("{$element_name_prefix}embedding_model", PARAM_TEXT);
-        $mform->addHelpButton("{$element_name_prefix}embedding_model", 'openai_embedding_model', 'local_mxaimanager');
+        self::add_model_field($mform, $element_name_prefix, 'embedding_model',
+            'default_embedding_model', 'openai_embedding_model',
+            interfaces\create_embedding::class, self::EMBEDDING_MODELS);
     }
 
     private static function add_image_model_field(\MoodleQuickForm $mform, string $element_name_prefix): void
     {
-        $mform->addElement(
-            'text',
-            "{$element_name_prefix}image_model",
-            get_string('default_image_model', 'local_mxaimanager'),
-            [
-                'action' => interfaces\create_image::class
-            ]
-        );
-        $mform->setType("{$element_name_prefix}image_model", PARAM_TEXT);
-        $mform->addHelpButton("{$element_name_prefix}image_model", 'openai_image_model', 'local_mxaimanager');
+        self::add_model_field($mform, $element_name_prefix, 'image_model',
+            'default_image_model', 'openai_image_model',
+            interfaces\create_image::class, self::IMAGE_MODELS);
     }
 
     private static function add_transcription_model_field(\MoodleQuickForm $mform, string $element_name_prefix): void
     {
-        $mform->addElement(
-            'text',
-            "{$element_name_prefix}transcription_model",
-            get_string('default_transcription_model', 'local_mxaimanager'),
-            [
-                'action' => interfaces\create_transcription::class
-            ]
-        );
-        $mform->setType("{$element_name_prefix}transcription_model", PARAM_TEXT);
-        $mform->addHelpButton(
-            "{$element_name_prefix}transcription_model",
-            'openai_transcription_model',
-            'local_mxaimanager'
-        );
+        self::add_model_field($mform, $element_name_prefix, 'transcription_model',
+            'default_transcription_model', 'openai_transcription_model',
+            interfaces\create_transcription::class, self::TRANSCRIPTION_MODELS);
     }
 
     public static function moodleform_definition(\MoodleQuickForm $mform, string $element_name_prefix): void

--- a/classes/app/ai/provider/providers/provider.php
+++ b/classes/app/ai/provider/providers/provider.php
@@ -61,4 +61,43 @@ abstract class provider
     {
         return str_replace(' ', '_', strtolower(static::class)) . '_';
     }
+
+    /**
+     * Add a model field as an autocomplete element with known models + free-text input.
+     *
+     * @param \MoodleQuickForm $mform
+     * @param string $element_name_prefix
+     * @param string $field_key e.g. 'chat_model'
+     * @param string $label_key lang string key for the label
+     * @param string $help_key lang string key for the help button
+     * @param string $action_interface The action interface class name
+     * @param array $known_models List of known model names (values shown in dropdown)
+     */
+    protected static function add_model_field(
+        \MoodleQuickForm $mform,
+        string $element_name_prefix,
+        string $field_key,
+        string $label_key,
+        string $help_key,
+        string $action_interface,
+        array $known_models = []
+    ): void {
+        $element_name = "{$element_name_prefix}{$field_key}";
+        $options = array_combine($known_models, $known_models);
+
+        $mform->addElement(
+            'autocomplete',
+            $element_name,
+            get_string($label_key, 'local_mxaimanager'),
+            $options,
+            [
+                'tags' => true,
+                'multiple' => false,
+                'noselectionstring' => get_string('model_type_or_select', 'local_mxaimanager'),
+                'action' => $action_interface,
+            ]
+        );
+        $mform->setType($element_name, PARAM_TEXT);
+        $mform->addHelpButton($element_name, $help_key, 'local_mxaimanager');
+    }
 }

--- a/lang/da/local_mxaimanager.php
+++ b/lang/da/local_mxaimanager.php
@@ -62,6 +62,7 @@ $string['uses_audio_transcriptions'] = 'Audio Transcriptions';
 
 $string['base_url'] = 'Base URL';
 $string['api_key'] = 'API Nøgle';
+$string['model_type_or_select'] = 'Select a model or type a custom one...';
 $string['default_chat_model'] = 'Standard Chat Model';
 $string['default_embedding_model'] = 'Standard Embedding Model';
 $string['default_image_model'] = 'Standard Billedmodel';

--- a/lang/en/local_mxaimanager.php
+++ b/lang/en/local_mxaimanager.php
@@ -62,6 +62,7 @@ $string['uses_audio_transcriptions'] = 'Audio Transcriptions';
 
 $string['base_url'] = 'Base URL';
 $string['api_key'] = 'API Key';
+$string['model_type_or_select'] = 'Select a model or type a custom one...';
 $string['default_chat_model'] = 'Default Chat Model';
 $string['default_embedding_model'] = 'Default Embedding Model';
 $string['default_image_model'] = 'Default Image Model';

--- a/lang/fr/local_mxaimanager.php
+++ b/lang/fr/local_mxaimanager.php
@@ -1,0 +1,100 @@
+<?php
+
+$string['pluginname'] = 'Moxis AI Manager';
+
+// Manage Providers
+$string['manage:info'] = "<p>Ces parametres vous permettent de definir quels fournisseurs d'IA (OpenAI, Mistral, etc.) sont disponibles sur votre site.</p><p>Vous pourrez egalement configurer :</p><ul><li>Quelle instance de fournisseur doit etre utilisee par defaut.</li><li>Quel modele une instance de fournisseur doit utiliser par defaut.</li><li>Quel modele et/ou quelle instance de fournisseur doit etre utilise pour une fonctionnalite IA specifique.</li></ul>";
+$string['manage_providers:title'] = 'Instances de fournisseurs IA';
+$string['manage_providers:table:name'] = 'Nom de l\'instance';
+$string['manage_providers:table:classname'] = 'Type de fournisseur';
+$string['manage_providers:table:supported_actions'] = 'Actions supportees';
+$string['manage_providers:table:actions'] = 'Actions';
+$string['manage_providers:form:name'] = 'Nom';
+$string['manage_providers:form:type'] = 'Type';
+$string['manage_providers:add_provider'] = 'Ajouter une instance de fournisseur IA';
+$string['manage_providers:edit_provider'] = 'Modifier une instance de fournisseur IA';
+$string['manage_providers:delete_provider'] = 'Supprimer l\'instance de fournisseur IA : "{$a}"';
+$string['manage_providers:delete_confirm'] = 'Etes-vous sur de vouloir supprimer cette instance de fournisseur ? Cette action est irreversible.';
+$string['here_you_define_providers'] = 'Definissez ici les instances de fournisseurs IA disponibles sur votre site.';
+$string['set_as_default'] = 'Definir par defaut ?';
+$string['in_use'] = 'Deja utilise';
+
+// Provider options help texts
+$string['openai_chat_model'] = 'Modele Chat OpenAI';
+$string['openai_chat_model_help'] = 'Specifiez le modele de chat a utiliser. Par exemple : <strong>gpt-5</strong>, <strong>gpt-4.1</strong>, etc. Consultez la documentation OpenAI pour les modeles disponibles.';
+$string['mistral_chat_model'] = 'Modele Chat Mistral';
+$string['mistral_chat_model_help'] = 'Specifiez le modele de chat a utiliser. Par exemple : <strong>mistral-large-3-25-12</strong>, <strong>mistral-small-3-2-25-06</strong>, etc. Consultez la documentation Mistral pour les modeles disponibles.';
+$string['ollama_chat_model'] = 'Modele Chat Ollama';
+$string['ollama_chat_model_help'] = 'Specifiez le modele de chat a utiliser. Par exemple : <strong>llama3.1</strong>, <strong>mistral</strong>, etc. Consultez votre fournisseur Ollama pour les modeles disponibles.';
+$string['nebius_chat_model'] = 'Modele Chat Nebius';
+$string['nebius_chat_model_help'] = 'Specifiez le modele de chat a utiliser. Par exemple : <strong>Qwen/Qwen3-32B-fast</strong>, etc. Consultez la documentation Nebius pour les modeles disponibles.';
+$string['openai_embedding_model'] = 'Modele Embedding OpenAI';
+$string['openai_embedding_model_help'] = 'Specifiez le modele d\'embedding a utiliser. Par exemple : <strong>text-embedding-3-small</strong>, <strong>text-embedding-3-large</strong>, etc.';
+$string['mistral_embedding_model'] = 'Modele Embedding Mistral';
+$string['mistral_embedding_model_help'] = 'Specifiez le modele d\'embedding a utiliser. Par exemple : <strong>mistral-embed-23-12</strong>, etc.';
+$string['ollama_embedding_model'] = 'Modele Embedding Ollama';
+$string['ollama_embedding_model_help'] = 'Specifiez le modele d\'embedding a utiliser. Par exemple : <strong>nomic-embed-text</strong>, etc.';
+$string['nebius_embedding_model'] = 'Modele Embedding Nebius';
+$string['nebius_embedding_model_help'] = 'Specifiez le modele d\'embedding a utiliser. Par exemple : <strong>BAAI/bge-en-icl</strong>, etc.';
+$string['openai_image_model'] = 'Modele Image OpenAI';
+$string['openai_image_model_help'] = 'Specifiez le modele de generation d\'images a utiliser. Par exemple : <strong>gpt-image-1.5</strong>, <strong>dall-e-3</strong>, etc.';
+$string['nebius_image_model'] = 'Modele Image Nebius';
+$string['nebius_image_model_help'] = 'Specifiez le modele de generation d\'images a utiliser. Par exemple : <strong>black-forest-labs/FLUX.1-schnell</strong>.';
+$string['openai_transcription_model'] = 'Modele Transcription OpenAI';
+$string['openai_transcription_model_help'] = 'Specifiez le modele de transcription a utiliser. Par exemple : <strong>gpt-4o-transcribe</strong>, <strong>whisper-1</strong>.';
+$string['mistral_transcription_model'] = 'Modele Transcription Mistral';
+$string['mistral_transcription_model_help'] = 'Specifiez le modele de transcription a utiliser. Par exemple : <strong>voxtral-mini-transcribe-26-02</strong>.';
+
+// Manage Features
+$string['manage_features:title'] = 'Fonctionnalites IA';
+$string['manage_features:table:component'] = 'Composant';
+$string['manage_features:table:name'] = 'Nom';
+$string['manage_features:table:description'] = 'Description';
+$string['manage_features:table:ai_actions'] = 'Actions IA requises';
+$string['manage_features:table:actions'] = 'Actions';
+$string['manage_features:edit_feature_settings'] = 'Modifier les parametres de la fonctionnalite IA : "{$a}"';
+$string['manage_features:form:provider_id'] = 'Instance de fournisseur';
+$string['here_you_can_see_all_components_ai_features'] = 'Voici toutes les fonctionnalites IA des composants disponibles sur votre site. Vous pouvez remplacer l\'instance de fournisseur par defaut et/ou les parametres pour chaque fonctionnalite.';
+$string['uses_chat'] = 'Chat';
+$string['uses_embedding'] = 'Embeddings';
+$string['uses_image'] = 'Image';
+$string['uses_audio_transcriptions'] = 'Transcription audio';
+
+$string['base_url'] = 'URL de base';
+$string['api_key'] = 'Cle API';
+$string['model_type_or_select'] = 'Selectionnez un modele ou saisissez-en un...';
+$string['default_chat_model'] = 'Modele Chat par defaut';
+$string['default_embedding_model'] = 'Modele Embedding par defaut';
+$string['default_image_model'] = 'Modele Image par defaut';
+$string['default_transcription_model'] = 'Modele Transcription par defaut';
+$string['provider_settings'] = 'Parametres du fournisseur';
+$string['supports_chat'] = 'Supporte le Chat';
+$string['supports_embedding'] = 'Supporte l\'Embedding';
+$string['supports_image'] = 'Supporte l\'Image';
+$string['supports_audio_transcriptions'] = 'Supporte la Transcription audio';
+$string['provider_supports'] = 'Capacites du fournisseur';
+$string['default_action_providers'] = 'Instances de fournisseurs par defaut';
+$string['here_you_define_default_action_providers'] = 'Definissez ici quelles instances de fournisseurs doivent etre utilisees par defaut pour chaque action.';
+$string['you_have_configured_a_provider_and_set_the_default'] = 'Vous avez configure une instance de fournisseur et defini le fournisseur par defaut pour toutes les actions. Vous etes pret a utiliser les fonctionnalites IA ! :)';
+$string['you_have_not_yet_configured_any_providers'] = 'Vous n\'avez pas encore configure d\'instance de fournisseur IA. Veuillez en ajouter au moins une <a href="/local/mxaimanager/view.php?view=manage_providers&action=browse">ici</a>.';
+$string['you_have_not_yet_configured_default_providers'] = 'Vous n\'avez pas encore configure les fournisseurs par defaut pour toutes les actions. Veuillez les configurer <a href="/local/mxaimanager/view.php?view=manage_providers&action=browse">ici</a>.';
+$string['no_available_providers'] = 'Aucune instance de fournisseur disponible';
+$string['this_provider_is_preconfigured_no_modify'] = 'Cette instance de fournisseur est preconfiguree et ne peut pas etre modifiee.';
+
+// Settings
+$string['settings:manage_page'] = 'Gerer les parametres IA';
+
+// Capabilities
+$string['mxaimanager:manage_configuration'] = 'Gerer la configuration de Moxis AI Manager';
+
+// Privacy
+$string['privacy:metadata:local_mxaimanager_feature_action_usage_logs'] = 'Cette table stocke les logs d\'utilisation des actions IA du plugin Moxis AI Manager.';
+$string['privacy:metadata:local_mxaimanager_feature_action_usage_logs:id'] = 'ID';
+$string['privacy:metadata:local_mxaimanager_feature_action_usage_logs:feature_id'] = 'L\'ID de la fonctionnalite IA utilisee.';
+$string['privacy:metadata:local_mxaimanager_feature_action_usage_logs:request_json'] = 'La requete JSON envoyee au fournisseur IA.';
+$string['privacy:metadata:local_mxaimanager_feature_action_usage_logs:response_json'] = 'La reponse JSON recue du fournisseur IA.';
+$string['privacy:metadata:local_mxaimanager_feature_action_usage_logs:input_tokens'] = 'Le nombre de tokens d\'entree utilises dans la requete.';
+$string['privacy:metadata:local_mxaimanager_feature_action_usage_logs:output_tokens'] = 'Le nombre de tokens de sortie recus dans la reponse.';
+$string['privacy:metadata:local_mxaimanager_feature_action_usage_logs:session_id'] = 'L\'ID de session associe a la requete.';
+$string['privacy:metadata:local_mxaimanager_feature_action_usage_logs:user_id'] = 'L\'ID de l\'utilisateur ayant effectue la requete.';
+$string['privacy:metadata:local_mxaimanager_feature_action_usage_logs:timecreated'] = 'L\'horodatage de creation de l\'entree de log.';


### PR DESCRIPTION
Model fields now use autocomplete dropdowns with predefined models per provider while still allowing free-text input for custom model names.

- OpenAI: updated model list (gpt-5.4, gpt-5, gpt-image-1.5, o3-pro, etc.)
- Mistral: updated model list (mistral-large-3-25-12, magistral-*, devstral-*, voxtral-*, etc.)
- Ollama: added common models (llama3.1, deepseek-r1, gemma2, etc.)
- Nebius: added known models (Meta-Llama-3.1-70B, DeepSeek-V3, FLUX.1-schnell, etc.)
- Added helper method `add_model_field()` in base provider class
- Added French translation (lang/fr/local_mxaimanager.php)