### PR TITLE
This branch is 4 commits ahead of tiny_courseaiimages and tiny_courseaiaudios

### DIFF
--- a/classes/app/ai/feature/action_handler.php
+++ b/classes/app/ai/feature/action_handler.php
@@ -10,6 +10,7 @@ defined('MOODLE_INTERNAL') || die();
 
 use local_mxaimanager\app\ai\provider\message;
 use local_mxaimanager\app\ai\provider\providers\interfaces\chat_completion;
+use local_mxaimanager\app\ai\provider\providers\interfaces\create_audio;
 use local_mxaimanager\app\ai\provider\providers\interfaces\create_embedding;
 use local_mxaimanager\app\ai\provider\providers\interfaces\create_image;
 use local_mxaimanager\app\ai\provider\providers\interfaces\create_transcription;
@@ -343,5 +344,51 @@ class action_handler
         ]);
 
         return $create_transcription_request->get_response();
+    }
+
+    /**
+     * @param entity $feature
+     * @param string $text The text to synthesize.
+     * @param int $provider_id
+     * @param array $config_json
+     * @return string Base64-encoded audio.
+     * @throws invalid_provider_instance_configuration
+     * @throws invalid_provider_instance_response
+     */
+    public function create_audio(
+        entity $feature,
+        string $text,
+        int $provider_id,
+        array $config_json
+    ): string {
+        // Get the provider handler.
+        $handler = $this->get_provider_handler_provider_and_settings_json(
+            $provider_id,
+            $config_json
+        );
+
+        // Validate interface.
+        if (!($handler instanceof create_audio)) {
+            throw new invalid_provider_instance_configuration(
+                'Provider instance ID: ' . $provider_id . ' does not support audio creation'
+            );
+        }
+
+        // Make the audio creation request.
+        $create_audio_request = $handler->create_audio($text);
+
+        // Log the request and response.
+        $this->base_factory->db()->insert_record('local_mxaimanager_feature_action_usage_logs', [
+            'feature_id' => $feature->get_id(),
+            'request_json' => json_encode($create_audio_request->get_request_json(), JSON_THROW_ON_ERROR),
+            'response_json' => json_encode($create_audio_request->get_response_json(), JSON_THROW_ON_ERROR),
+            'input_tokens' => $create_audio_request->get_input_tokens(),
+            'output_tokens' => $create_audio_request->get_output_tokens(),
+            'session_id' => session_id(),
+            'user_id' => $this->base_factory->user()->id,
+            'timecreated' => time(),
+        ]);
+
+        return $create_audio_request->get_response();
     }
 }

--- a/classes/app/ai/feature/handler.php
+++ b/classes/app/ai/feature/handler.php
@@ -123,4 +123,31 @@ class handler
             $config_json
         );
     }
+
+    /**
+     * Synthesize audio (text-to-speech) from a text input.
+     *
+     * Returns the base64-encoded audio binary. Mimetype/format is determined by the
+     * provider config (`tts_format`).
+     *
+     * @param string $text
+     * @return string Base64-encoded audio.
+     * @throws invalid_provider_instance_configuration
+     * @throws invalid_provider_instance_response
+     * @throws no_provider_instance_configured
+     */
+    public function create_audio(string $text): string
+    {
+        // Get provider_id and settings_json for the action.
+        [$provider_id, $config_json] = $this->provider_resolver->get_provider_and_config(
+            \local_mxaimanager\app\ai\provider\providers\interfaces\create_audio::class
+        );
+
+        return $this->action_handler->create_audio(
+            $this->feature,
+            $text,
+            $provider_id,
+            $config_json
+        );
+    }
 }

--- a/classes/app/ai/provider/create_audio_request.php
+++ b/classes/app/ai/provider/create_audio_request.php
@@ -1,0 +1,90 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_mxaimanager\app\ai\provider;
+
+
+// @codeCoverageIgnoreStart
+defined('MOODLE_INTERNAL') || die();
+
+// @codeCoverageIgnoreEnd
+
+/**
+ * Request DTO for text-to-speech generation.
+ *
+ * `response` is the base64-encoded audio binary. The mimetype is determined by the provider
+ * config (`tts_format`) and is the consumer's responsibility to track separately if needed.
+ *
+ * @package local_mxaimanager
+ */
+class create_audio_request implements \JsonSerializable
+{
+    protected array $request_json;
+    protected array $response_json;
+    protected string $response;
+    protected int $input_tokens;
+    protected int $output_tokens;
+
+    public function __construct(
+        array $request_json,
+        array $response_json,
+        string $response,
+        int $input_tokens,
+        int $output_tokens
+    ) {
+        $this->request_json = $request_json;
+        $this->response_json = $response_json;
+        $this->response = $response;
+        $this->input_tokens = $input_tokens;
+        $this->output_tokens = $output_tokens;
+    }
+
+    public function get_request_json(): array
+    {
+        return $this->request_json;
+    }
+
+    public function get_response_json(): array
+    {
+        return $this->response_json;
+    }
+
+    public function get_response(): string
+    {
+        return $this->response;
+    }
+
+    public function get_input_tokens(): int
+    {
+        return $this->input_tokens;
+    }
+
+    public function get_output_tokens(): int
+    {
+        return $this->output_tokens;
+    }
+
+    public function jsonSerialize(): array
+    {
+        return [
+            'request_json' => $this->get_request_json(),
+            'response_json' => $this->get_response_json(),
+            'response' => $this->get_response(),
+            'input_tokens' => $this->get_input_tokens(),
+            'output_tokens' => $this->get_output_tokens(),
+        ];
+    }
+}

--- a/classes/app/ai/provider/factory.php
+++ b/classes/app/ai/provider/factory.php
@@ -49,7 +49,8 @@ class factory
             \local_mxaimanager\app\ai\provider\providers\interfaces\chat_completion::class => 'Chat',
             \local_mxaimanager\app\ai\provider\providers\interfaces\create_embedding::class => 'Embedding',
             \local_mxaimanager\app\ai\provider\providers\interfaces\create_image::class => 'Image',
-            \local_mxaimanager\app\ai\provider\providers\interfaces\create_transcription::class => 'Audio Transcription'
+            \local_mxaimanager\app\ai\provider\providers\interfaces\create_transcription::class => 'Audio Transcription',
+            \local_mxaimanager\app\ai\provider\providers\interfaces\create_audio::class => 'Text-to-Speech',
         ];
     }
 

--- a/classes/app/ai/provider/providers/interfaces/create_audio.php
+++ b/classes/app/ai/provider/providers/interfaces/create_audio.php
@@ -1,0 +1,46 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+namespace local_mxaimanager\app\ai\provider\providers\interfaces;
+
+// @codeCoverageIgnoreStart
+defined('MOODLE_INTERNAL') || die();
+
+// @codeCoverageIgnoreEnd
+
+use local_mxaimanager\app\ai\provider\create_audio_request;
+use local_mxaimanager\app\exceptions\invalid_provider_instance_configuration;
+use local_mxaimanager\app\exceptions\invalid_provider_instance_response;
+
+/**
+ * Provider capability contract: synthesize audio (TTS) from a text input.
+ *
+ * @package local_mxaimanager
+ * @copyright Tresipunt
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+interface create_audio {
+
+    /**
+     * Generate audio (text-to-speech) from a text input.
+     *
+     * @param string $text The text to synthesize.
+     * @return create_audio_request The request DTO carrying the base64-encoded audio in `response`.
+     * @throws invalid_provider_instance_configuration
+     * @throws invalid_provider_instance_response
+     */
+    public function create_audio(string $text): create_audio_request;
+}

--- a/classes/app/ai/provider/providers/openai.php
+++ b/classes/app/ai/provider/providers/openai.php
@@ -9,6 +9,7 @@ defined('MOODLE_INTERNAL') || die();
 // @codeCoverageIgnoreEnd
 
 use local_mxaimanager\app\ai\provider\chat_completion_request;
+use local_mxaimanager\app\ai\provider\create_audio_request;
 use local_mxaimanager\app\ai\provider\create_embedding_request;
 use local_mxaimanager\app\ai\provider\create_transcription_request;
 use local_mxaimanager\app\ai\provider\image_generation_request;
@@ -18,8 +19,14 @@ use local_mxaimanager\app\exceptions\invalid_provider_instance_response;
 use local_mxaimanager\app\factory as base_factory;
 
 class openai extends provider implements interfaces\chat_completion, interfaces\create_embedding,
-                                         interfaces\create_image, interfaces\create_transcription
+                                         interfaces\create_image, interfaces\create_transcription,
+                                         interfaces\create_audio
 {
+    private const TTS_ALLOWED_VOICES = ['alloy', 'echo', 'fable', 'onyx', 'nova', 'shimmer'];
+    private const TTS_ALLOWED_FORMATS = ['mp3', 'opus', 'aac', 'flac', 'wav', 'pcm'];
+    private const TTS_DEFAULT_VOICE = 'alloy';
+    private const TTS_DEFAULT_FORMAT = 'mp3';
+
     private \curl $curl;
     private string $base_url;
     private string $api_key;
@@ -27,6 +34,9 @@ class openai extends provider implements interfaces\chat_completion, interfaces\
     private string $embedding_model;
     private string $image_model;
     private string $transcription_model;
+    private string $tts_model;
+    private string $tts_voice;
+    private string $tts_format;
 
     /**
      * @throws invalid_provider_instance_configuration
@@ -40,6 +50,9 @@ class openai extends provider implements interfaces\chat_completion, interfaces\
         $this->embedding_model = $json_config['embedding_model'] ?? '';
         $this->image_model = $json_config['image_model'] ?? '';
         $this->transcription_model = $json_config['transcription_model'] ?? '';
+        $this->tts_model = $json_config['tts_model'] ?? '';
+        $this->tts_voice = $json_config['tts_voice'] ?? '';
+        $this->tts_format = $json_config['tts_format'] ?? '';
 
         if (empty($this->base_url) || empty($this->api_key)) {
             throw new invalid_provider_instance_configuration('OpenAI is missing base url and/or api key');
@@ -112,6 +125,52 @@ class openai extends provider implements interfaces\chat_completion, interfaces\
         );
     }
 
+    private static function add_tts_model_field(\MoodleQuickForm $mform, string $element_name_prefix): void
+    {
+        $mform->addElement(
+            'text',
+            "{$element_name_prefix}tts_model",
+            get_string('default_tts_model', 'local_mxaimanager'),
+            [
+                'action' => interfaces\create_audio::class
+            ]
+        );
+        $mform->setType("{$element_name_prefix}tts_model", PARAM_TEXT);
+        $mform->addHelpButton("{$element_name_prefix}tts_model", 'openai_tts_model', 'local_mxaimanager');
+    }
+
+    private static function add_tts_voice_field(\MoodleQuickForm $mform, string $element_name_prefix): void
+    {
+        $voice_options = array_combine(self::TTS_ALLOWED_VOICES, self::TTS_ALLOWED_VOICES);
+        $mform->addElement(
+            'select',
+            "{$element_name_prefix}tts_voice",
+            get_string('default_tts_voice', 'local_mxaimanager'),
+            $voice_options,
+            [
+                'action' => interfaces\create_audio::class
+            ]
+        );
+        $mform->setDefault("{$element_name_prefix}tts_voice", self::TTS_DEFAULT_VOICE);
+        $mform->addHelpButton("{$element_name_prefix}tts_voice", 'openai_tts_voice', 'local_mxaimanager');
+    }
+
+    private static function add_tts_format_field(\MoodleQuickForm $mform, string $element_name_prefix): void
+    {
+        $format_options = array_combine(self::TTS_ALLOWED_FORMATS, self::TTS_ALLOWED_FORMATS);
+        $mform->addElement(
+            'select',
+            "{$element_name_prefix}tts_format",
+            get_string('default_tts_format', 'local_mxaimanager'),
+            $format_options,
+            [
+                'action' => interfaces\create_audio::class
+            ]
+        );
+        $mform->setDefault("{$element_name_prefix}tts_format", self::TTS_DEFAULT_FORMAT);
+        $mform->addHelpButton("{$element_name_prefix}tts_format", 'openai_tts_format', 'local_mxaimanager');
+    }
+
     public static function moodleform_definition(\MoodleQuickForm $mform, string $element_name_prefix): void
     {
         // Add base_url field
@@ -135,6 +194,11 @@ class openai extends provider implements interfaces\chat_completion, interfaces\
 
         // Add transcription model field
         self::add_transcription_model_field($mform, $element_name_prefix);
+
+        // Add TTS fields.
+        self::add_tts_model_field($mform, $element_name_prefix);
+        self::add_tts_voice_field($mform, $element_name_prefix);
+        self::add_tts_format_field($mform, $element_name_prefix);
     }
 
     public static function moodleform_validation(array $data, string $element_name_prefix): array
@@ -165,6 +229,10 @@ class openai extends provider implements interfaces\chat_completion, interfaces\
             $errors["{$element_name_prefix}transcription_model"] = get_string('required');
         }
 
+        if (empty($data["{$element_name_prefix}tts_model"])) {
+            $errors["{$element_name_prefix}tts_model"] = get_string('required');
+        }
+
         return $errors;
     }
 
@@ -185,6 +253,11 @@ class openai extends provider implements interfaces\chat_completion, interfaces\
                 break;
             case interfaces\create_transcription::class:
                 self::add_transcription_model_field($mform, $element_name_prefix);
+                break;
+            case interfaces\create_audio::class:
+                self::add_tts_model_field($mform, $element_name_prefix);
+                self::add_tts_voice_field($mform, $element_name_prefix);
+                self::add_tts_format_field($mform, $element_name_prefix);
                 break;
             default:
         }
@@ -397,6 +470,71 @@ class openai extends provider implements interfaces\chat_completion, interfaces\
                 "Authorization: Bearer {$this->api_key}",
                 'Content-Type: application/json'
             ]);
+        }
+    }
+
+    /**
+     * @throws invalid_provider_instance_configuration
+     * @throws invalid_provider_instance_response
+     */
+    public function create_audio(string $text): create_audio_request
+    {
+        if (empty($this->tts_model)) {
+            throw new invalid_provider_instance_configuration('TTS model is not configured');
+        }
+
+        $voice = $this->tts_voice !== '' ? $this->tts_voice : self::TTS_DEFAULT_VOICE;
+        if (!in_array($voice, self::TTS_ALLOWED_VOICES, true)) {
+            throw new invalid_provider_instance_configuration(
+                'TTS voice "' . $voice . '" is not supported by OpenAI. Allowed: '
+                    . implode(', ', self::TTS_ALLOWED_VOICES)
+            );
+        }
+
+        $format = $this->tts_format !== '' ? $this->tts_format : self::TTS_DEFAULT_FORMAT;
+        if (!in_array($format, self::TTS_ALLOWED_FORMATS, true)) {
+            throw new invalid_provider_instance_configuration(
+                'TTS format "' . $format . '" is not supported by OpenAI. Allowed: '
+                    . implode(', ', self::TTS_ALLOWED_FORMATS)
+            );
+        }
+
+        $payload = [
+            'model' => $this->tts_model,
+            'input' => $text,
+            'voice' => $voice,
+            'response_format' => $format,
+        ];
+
+        try {
+            $response = $this->curl->post(
+                "{$this->base_url}/v1/audio/speech",
+                json_encode($payload, JSON_THROW_ON_ERROR)
+            );
+
+            // OpenAI TTS returns the raw audio bytes (not JSON). If the body parses as JSON
+            // with an "error" key, the API rejected the request — surface that.
+            $decoded = json_decode($response, true);
+            if (is_array($decoded) && isset($decoded['error'])) {
+                throw new \Exception('OpenAI TTS error: ' . json_encode($decoded['error']));
+            }
+
+            if ($response === '' || $response === false) {
+                throw new \Exception('Empty audio response from OpenAI TTS');
+            }
+
+            return new create_audio_request(
+                $payload,
+                [],
+                base64_encode($response),
+                0,
+                0
+            );
+        } catch (\Throwable $t) {
+            throw new invalid_provider_instance_response(
+                'Invalid response from OpenAI: ' . $t->getMessage(),
+                previous: $t
+            );
         }
     }
 }

--- a/classes/app/ai/provider/providers/openai.php
+++ b/classes/app/ai/provider/providers/openai.php
@@ -308,9 +308,10 @@ class openai extends provider implements interfaces\chat_completion, interfaces\
         $payload = [
             'model' => $this->image_model,
             'prompt' => $prompt,
-            'response_format' => $return_b64 ? 'b64_json' : 'url',
         ];
-
+        if (!$return_b64) {
+            throw new \Exception('Openai new API only accepts b64_json');
+        }
         try {
             $response = $this->curl->post(
                 "{$this->base_url}/v1/images/generations",
@@ -319,14 +320,14 @@ class openai extends provider implements interfaces\chat_completion, interfaces\
 
             $json = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
 
-            if (!isset($json['data'][0][$return_b64 ? 'b64_json' : 'url'])) {
+            if (!isset($json['data'][0]['b64_json'])) {
                 throw new \Exception('Missing image data in OpenAI response. OpenAI response: ' . $response);
             }
 
             return new image_generation_request(
                 $payload,
                 $json,
-                $json['data'][0][$return_b64 ? 'b64_json' : 'url'],
+                $json['data'][0]['b64_json'],
                 0,
                 0
             );

--- a/classes/output/manage_features/table_ai_actions.php
+++ b/classes/output/manage_features/table_ai_actions.php
@@ -51,6 +51,11 @@ class table_ai_actions implements \renderable, \core\output\named_templatable
                 $used_interfaces,
                 true
             ),
+            'audio' => in_array(
+                \local_mxaimanager\app\ai\provider\providers\interfaces\create_audio::class,
+                $used_interfaces,
+                true
+            ),
         ];
     }
 }

--- a/classes/output/manage_providers/form_provider_supports.php
+++ b/classes/output/manage_providers/form_provider_supports.php
@@ -57,6 +57,11 @@ class form_provider_supports implements named_templatable, renderable
                 $implemented_classes,
                 true
             ),
+            'audio' => in_array(
+                \local_mxaimanager\app\ai\provider\providers\interfaces\create_audio::class,
+                $implemented_classes,
+                true
+            ),
         ];
     }
 }

--- a/lang/ca/local_mxaimanager.php
+++ b/lang/ca/local_mxaimanager.php
@@ -1,0 +1,39 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Catalan strings for the Moxis AI Manager plugin.
+ *
+ * Only contains the keys introduced by the TTS extension (ticket
+ * tiny_courseaiaudio-2). The rest of the plugin was not translated to Catalan
+ * prior to this change; that gap is preexisting and out of scope for this ticket.
+ *
+ * @package local_mxaimanager
+ * @copyright Tresipunt
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['default_tts_format'] = 'Format Text-to-Speech per defecte';
+$string['default_tts_model'] = 'Model Text-to-Speech per defecte';
+$string['default_tts_voice'] = 'Veu Text-to-Speech per defecte';
+$string['openai_tts_format'] = 'Format Text-to-Speech d\'OpenAI';
+$string['openai_tts_format_help'] = 'Format de contenidor d\'àudio retornat per OpenAI. <strong>mp3</strong> és l\'opció més segura per a l\'etiqueta HTML5 audio; també es suporten <strong>opus</strong>, <strong>aac</strong>, <strong>flac</strong>, <strong>wav</strong> i <strong>pcm</strong>.';
+$string['openai_tts_model'] = 'Model Text-to-Speech d\'OpenAI';
+$string['openai_tts_model_help'] = 'Aquí pots especificar el model TTS (text-to-speech) que s\'ha d\'utilitzar. Per exemple: <strong>tts-1</strong>, <strong>tts-1-hd</strong>. Consulta la documentació d\'OpenAI per veure els models disponibles.';
+$string['openai_tts_voice'] = 'Veu Text-to-Speech d\'OpenAI';
+$string['openai_tts_voice_help'] = 'Veu utilitzada per sintetitzar l\'àudio. OpenAI suporta actualment: <strong>alloy</strong>, <strong>echo</strong>, <strong>fable</strong>, <strong>onyx</strong>, <strong>nova</strong>, <strong>shimmer</strong>.';
+$string['supports_tts'] = 'Suporta Text-to-Speech';
+$string['uses_tts'] = 'Text-to-Speech';

--- a/lang/da/local_mxaimanager.php
+++ b/lang/da/local_mxaimanager.php
@@ -44,6 +44,12 @@ $string['openai_transcription_model'] = 'OpenAI Transcription Model';
 $string['openai_transcription_model_help'] = 'Here you can specify the transcription model that should be used. For example: <strong>whisper-1</strong>. Refer to OpenAI\'s documentation for available transcription models.';
 $string['mistral_transcription_model'] = 'Mistral Transcription Model';
 $string['mistral_transcription_model_help'] = 'Here you can specify the transcription model that should be used. For example: <strong>mistral-whisper</strong>. Refer to Mistral\'s documentation for available transcription models.';
+$string['openai_tts_model'] = 'OpenAI Text-to-Speech Model';
+$string['openai_tts_model_help'] = 'Her kan du angive den TTS-model (text-to-speech), der skal bruges. For eksempel: <strong>tts-1</strong>, <strong>tts-1-hd</strong>. Se OpenAI\'s dokumentation for tilgængelige TTS-modeller.';
+$string['openai_tts_voice'] = 'OpenAI Text-to-Speech Stemme';
+$string['openai_tts_voice_help'] = 'Stemme der bruges til at syntetisere lyden. OpenAI understøtter aktuelt: <strong>alloy</strong>, <strong>echo</strong>, <strong>fable</strong>, <strong>onyx</strong>, <strong>nova</strong>, <strong>shimmer</strong>.';
+$string['openai_tts_format'] = 'OpenAI Text-to-Speech Format';
+$string['openai_tts_format_help'] = 'Lydcontainerformat returneret af OpenAI. <strong>mp3</strong> er det sikreste valg for HTML5 audio-tagget; <strong>opus</strong>, <strong>aac</strong>, <strong>flac</strong>, <strong>wav</strong> og <strong>pcm</strong> understøttes også.';
 
 // Manage Features
 $string['manage_features:title'] = 'AI Funktioner';
@@ -59,6 +65,7 @@ $string['uses_chat'] = 'Chat';
 $string['uses_embedding'] = 'Embeddings';
 $string['uses_image'] = 'Image';
 $string['uses_audio_transcriptions'] = 'Audio Transcriptions';
+$string['uses_tts'] = 'Text-to-Speech';
 
 $string['base_url'] = 'Base URL';
 $string['api_key'] = 'API Nøgle';
@@ -66,11 +73,15 @@ $string['default_chat_model'] = 'Standard Chat Model';
 $string['default_embedding_model'] = 'Standard Embedding Model';
 $string['default_image_model'] = 'Standard Billedmodel';
 $string['default_transcription_model'] = 'Standard Transkriptionsmodel';
+$string['default_tts_model'] = 'Standard Text-to-Speech Model';
+$string['default_tts_voice'] = 'Standard Text-to-Speech Stemme';
+$string['default_tts_format'] = 'Standard Text-to-Speech Format';
 $string['provider_settings'] = 'Provider Indstillinger';
 $string['supports_chat'] = 'Understøtter Chat';
 $string['supports_embedding'] = 'Understøtter Embedding';
 $string['supports_image'] = 'Understøtter Billede';
 $string['supports_audio_transcriptions'] = 'Understøtter Audio Transkriptioner';
+$string['supports_tts'] = 'Understøtter Text-to-Speech';
 $string['provider_supports'] = 'Provider Kapaciteter';
 $string['default_action_providers'] = 'Standard Handling Provider-instanser';
 $string['here_you_define_default_action_providers'] = 'Her definerer du, hvilke provider-instanser der skal bruges som standard for hver handling.';

--- a/lang/en/local_mxaimanager.php
+++ b/lang/en/local_mxaimanager.php
@@ -44,6 +44,12 @@ $string['openai_transcription_model'] = 'OpenAI Transcription Model';
 $string['openai_transcription_model_help'] = 'Here you can specify the transcription model that should be used. For example: <strong>whisper-1</strong>. Refer to OpenAI\'s documentation for available transcription models.';
 $string['mistral_transcription_model'] = 'Mistral Transcription Model';
 $string['mistral_transcription_model_help'] = 'Here you can specify the transcription model that should be used. For example: <strong>mistral-whisper</strong>. Refer to Mistral\'s documentation for available transcription models.';
+$string['openai_tts_model'] = 'OpenAI Text-to-Speech Model';
+$string['openai_tts_model_help'] = 'Here you can specify the TTS (text-to-speech) model that should be used. For example: <strong>tts-1</strong>, <strong>tts-1-hd</strong>. Refer to OpenAI\'s documentation for available TTS models.';
+$string['openai_tts_voice'] = 'OpenAI Text-to-Speech Voice';
+$string['openai_tts_voice_help'] = 'Voice used to synthesize the audio. OpenAI currently supports: <strong>alloy</strong>, <strong>echo</strong>, <strong>fable</strong>, <strong>onyx</strong>, <strong>nova</strong>, <strong>shimmer</strong>.';
+$string['openai_tts_format'] = 'OpenAI Text-to-Speech Format';
+$string['openai_tts_format_help'] = 'Audio container format returned by OpenAI. <strong>mp3</strong> is the safest choice for the HTML5 audio tag; <strong>opus</strong>, <strong>aac</strong>, <strong>flac</strong>, <strong>wav</strong> and <strong>pcm</strong> are also supported.';
 
 // Manage Features
 $string['manage_features:title'] = 'AI Features';
@@ -59,6 +65,7 @@ $string['uses_chat'] = 'Chat';
 $string['uses_embedding'] = 'Embeddings';
 $string['uses_image'] = 'Image';
 $string['uses_audio_transcriptions'] = 'Audio Transcriptions';
+$string['uses_tts'] = 'Text-to-Speech';
 
 $string['base_url'] = 'Base URL';
 $string['api_key'] = 'API Key';
@@ -66,11 +73,15 @@ $string['default_chat_model'] = 'Default Chat Model';
 $string['default_embedding_model'] = 'Default Embedding Model';
 $string['default_image_model'] = 'Default Image Model';
 $string['default_transcription_model'] = 'Default Transcription Model';
+$string['default_tts_model'] = 'Default Text-to-Speech Model';
+$string['default_tts_voice'] = 'Default Text-to-Speech Voice';
+$string['default_tts_format'] = 'Default Text-to-Speech Format';
 $string['provider_settings'] = 'Provider Settings';
 $string['supports_chat'] = 'Supports Chat';
 $string['supports_embedding'] = 'Supports Embedding';
 $string['supports_image'] = 'Supports Image';
 $string['supports_audio_transcriptions'] = 'Supports Audio Transcriptions';
+$string['supports_tts'] = 'Supports Text-to-Speech';
 $string['provider_supports'] = 'Provider Capabilities';
 $string['default_action_providers'] = 'Default Action Provider instances';
 $string['here_you_define_default_action_providers'] = 'Here you define which provider instances should be used by default for each action.';

--- a/lang/es/local_mxaimanager.php
+++ b/lang/es/local_mxaimanager.php
@@ -1,0 +1,39 @@
+<?php
+// This file is part of Moodle - https://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <https://www.gnu.org/licenses/>.
+
+/**
+ * Spanish strings for the Moxis AI Manager plugin.
+ *
+ * Only contains the keys introduced by the TTS extension (ticket
+ * tiny_courseaiaudio-2). The rest of the plugin was not translated to Spanish
+ * prior to this change; that gap is preexisting and out of scope for this ticket.
+ *
+ * @package local_mxaimanager
+ * @copyright Tresipunt
+ * @license http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+$string['default_tts_format'] = 'Formato Text-to-Speech por defecto';
+$string['default_tts_model'] = 'Modelo Text-to-Speech por defecto';
+$string['default_tts_voice'] = 'Voz Text-to-Speech por defecto';
+$string['openai_tts_format'] = 'Formato Text-to-Speech de OpenAI';
+$string['openai_tts_format_help'] = 'Formato de contenedor de audio devuelto por OpenAI. <strong>mp3</strong> es la opción más segura para la etiqueta HTML5 audio; también se soportan <strong>opus</strong>, <strong>aac</strong>, <strong>flac</strong>, <strong>wav</strong> y <strong>pcm</strong>.';
+$string['openai_tts_model'] = 'Modelo Text-to-Speech de OpenAI';
+$string['openai_tts_model_help'] = 'Aquí puedes especificar el modelo TTS (text-to-speech) a utilizar. Por ejemplo: <strong>tts-1</strong>, <strong>tts-1-hd</strong>. Consulta la documentación de OpenAI para ver los modelos disponibles.';
+$string['openai_tts_voice'] = 'Voz Text-to-Speech de OpenAI';
+$string['openai_tts_voice_help'] = 'Voz utilizada para sintetizar el audio. OpenAI soporta actualmente: <strong>alloy</strong>, <strong>echo</strong>, <strong>fable</strong>, <strong>onyx</strong>, <strong>nova</strong>, <strong>shimmer</strong>.';
+$string['supports_tts'] = 'Soporta Text-to-Speech';
+$string['uses_tts'] = 'Text-to-Speech';

--- a/templates/manage_features/table_ai_actions.mustache
+++ b/templates/manage_features/table_ai_actions.mustache
@@ -24,5 +24,11 @@
                 {{#str}}uses_audio_transcriptions, local_mxaimanager{{/str}}
             </li>
         {{/transcription}}
+        {{#audio}}
+            <li>
+                <i class="fa fa-square-check"></i>
+                {{#str}}uses_tts, local_mxaimanager{{/str}}
+            </li>
+        {{/audio}}
     </ul>
 </div>

--- a/templates/manage_providers/form_provider_supports.mustache
+++ b/templates/manage_providers/form_provider_supports.mustache
@@ -37,5 +37,14 @@
             {{/transcription}}
             {{#str}}supports_audio_transcriptions, local_mxaimanager{{/str}}
         </li>
+        <li>
+            {{#audio}}
+                <i class="fa fa-square-check"></i>
+            {{/audio}}
+            {{^audio}}
+                <i class="fa fa-square-o"></i>
+            {{/audio}}
+            {{#str}}supports_tts, local_mxaimanager{{/str}}
+        </li>
     </ul>
 </div>

--- a/tests/unit/app/ai/feature/action_handler_test.php
+++ b/tests/unit/app/ai/feature/action_handler_test.php
@@ -17,7 +17,9 @@ use local_mxaimanager\app\factory as base_factory;
 use local_mxaimanager\app\ai\provider\message;
 use local_mxaimanager\app\ai\feature\action_handler;
 use local_mxaimanager\app\ai\provider\providers\interfaces\chat_completion;
+use local_mxaimanager\app\ai\provider\providers\interfaces\create_audio;
 use local_mxaimanager\app\ai\provider\providers\interfaces\create_embedding;
+use local_mxaimanager\app\ai\provider\create_audio_request;
 
 /**
  * Mock handler class that has methods but doesn't implement interfaces
@@ -507,4 +509,58 @@ class action_handler_test extends base_testcase
         $this->assertEquals('{"partial":"value"}', $result);
     }
 
+    public function test_create_audio_success(): void
+    {
+        $base_factory_mock = $this->createMock(base_factory::class);
+        $provider_handler_mock = $this->createMock(create_audio::class);
+
+        $handler = $this->getMockBuilder(action_handler::class)
+            ->setConstructorArgs([$base_factory_mock])
+            ->onlyMethods(['get_provider_handler_provider_and_settings_json'])
+            ->getMock();
+
+        $handler->expects($this->once())
+            ->method('get_provider_handler_provider_and_settings_json')
+            ->with(7, ['tts_model' => 'tts-1'])
+            ->willReturn($provider_handler_mock);
+
+        $provider_handler_mock->expects($this->once())
+            ->method('create_audio')
+            ->with('Hola mundo')
+            ->willReturn(new create_audio_request(
+                ['model' => 'tts-1', 'input' => 'Hola mundo', 'voice' => 'alloy', 'response_format' => 'mp3'],
+                [],
+                'base64audiopayload',
+                0,
+                0
+            ));
+
+        $result = $handler->create_audio(new entity(), 'Hola mundo', 7, ['tts_model' => 'tts-1']);
+
+        $this->assertEquals('base64audiopayload', $result);
+    }
+
+    public function test_create_audio_provider_not_supporting_interface(): void
+    {
+        // Reuse the existing MockHandlerWithoutInterface (it implements neither create_audio
+        // nor any other action interface) to trigger the validation error.
+        $handler_instance = new MockHandlerWithoutInterface();
+
+        $base_factory_mock = $this->createMock(base_factory::class);
+
+        $handler = $this->getMockBuilder(action_handler::class)
+            ->setConstructorArgs([$base_factory_mock])
+            ->onlyMethods(['get_provider_handler_provider_and_settings_json'])
+            ->getMock();
+
+        $handler->expects($this->once())
+            ->method('get_provider_handler_provider_and_settings_json')
+            ->with(99, ['foo' => 'bar'])
+            ->willReturn($handler_instance);
+
+        $this->expectException(invalid_provider_instance_configuration::class);
+        $this->expectExceptionMessage('Provider instance ID: 99 does not support audio creation');
+
+        $handler->create_audio(new entity(), 'Hello', 99, ['foo' => 'bar']);
+    }
 }

--- a/tests/unit/app/ai/feature/handler_test.php
+++ b/tests/unit/app/ai/feature/handler_test.php
@@ -139,4 +139,53 @@ class handler_test extends base_testcase
         // Assert results
         $this->assertEquals([0.1, 0.2, 0.3], $result);
     }
+
+    public function test_create_audio(): void
+    {
+        $provider_resolver_mock = $this->createMock(provider_resolver::class);
+        $action_handler_mock = $this->createMock(action_handler::class);
+
+        $provider_resolver_mock->expects($this->once())
+            ->method('get_provider_and_config')
+            ->with(\local_mxaimanager\app\ai\provider\providers\interfaces\create_audio::class)
+            ->willReturn([7, ['tts_model' => 'tts-1']]);
+
+        $action_handler_mock->expects($this->once())
+            ->method('create_audio')
+            ->with(
+                $this->isInstanceOf(entity::class),
+                $this->equalTo('Hola mundo'),
+                $this->equalTo(7),
+                $this->equalTo(['tts_model' => 'tts-1'])
+            )
+            ->willReturn('base64audiopayload');
+
+        $base_factory_mock = $this->createMock(base_factory::class);
+        $ai_factory_mock = $this->createMock(ai_factory::class);
+        $feature_factory_mock = $this->createMock(feature_factory::class);
+
+        $base_factory_mock->expects($this->exactly(2))
+            ->method('ai')
+            ->willReturn($ai_factory_mock);
+
+        $ai_factory_mock->expects($this->exactly(2))
+            ->method('feature')
+            ->willReturn($feature_factory_mock);
+
+        $feature_factory_mock->expects($this->once())
+            ->method('provider_resolver')
+            ->willReturn($provider_resolver_mock);
+
+        $feature_factory_mock->expects($this->once())
+            ->method('action_handler')
+            ->willReturn($action_handler_mock);
+
+        $feature_entity_mock = $this->createMock(entity::class);
+
+        $handler = new handler($base_factory_mock, $feature_entity_mock);
+
+        $result = $handler->create_audio('Hola mundo');
+
+        $this->assertEquals('base64audiopayload', $result);
+    }
 }

--- a/tests/unit/app/ai/provider/factory_test.php
+++ b/tests/unit/app/ai/provider/factory_test.php
@@ -57,6 +57,7 @@ class factory_test extends \base_testcase
         $expected_actions = [
             \local_mxaimanager\app\ai\provider\providers\interfaces\chat_completion::class,
             \local_mxaimanager\app\ai\provider\providers\interfaces\create_embedding::class,
+            \local_mxaimanager\app\ai\provider\providers\interfaces\create_audio::class,
         ];
 
         foreach ($expected_actions as $action_interface) {
@@ -70,6 +71,39 @@ class factory_test extends \base_testcase
             $this->assertIsString($display_name);
             $this->assertNotEmpty($display_name);
         }
+    }
+
+    public function test_get_providers_supporting_action_create_audio(): void
+    {
+        $factory = \local_mxaimanager\app\factory::make();
+
+        $ai_factory = $factory->ai();
+        $provider_factory = $ai_factory->provider();
+
+        $audio_providers = $provider_factory->get_providers_supporting_action(
+            \local_mxaimanager\app\ai\provider\providers\interfaces\create_audio::class
+        );
+
+        // OpenAI is the only provider implementing the TTS interface in this phase.
+        $this->assertIsArray($audio_providers);
+        $this->assertContains(
+            \local_mxaimanager\app\ai\provider\providers\openai::class,
+            $audio_providers
+        );
+
+        // Other providers must NOT implement TTS yet.
+        $this->assertNotContains(
+            \local_mxaimanager\app\ai\provider\providers\mistral::class,
+            $audio_providers
+        );
+        $this->assertNotContains(
+            \local_mxaimanager\app\ai\provider\providers\nebius::class,
+            $audio_providers
+        );
+        $this->assertNotContains(
+            \local_mxaimanager\app\ai\provider\providers\ollama::class,
+            $audio_providers
+        );
     }
 
     public function test_get_providers_supporting_action_chat_completion(): void

--- a/tests/unit/app/ai/provider/providers/openai_test.php
+++ b/tests/unit/app/ai/provider/providers/openai_test.php
@@ -11,8 +11,10 @@ global $CFG;
 require_once $CFG->libdir . '/formslib.php';
 
 use local_mxaimanager\app\ai\provider\providers\interfaces\chat_completion;
+use local_mxaimanager\app\ai\provider\providers\interfaces\create_audio;
 use local_mxaimanager\app\ai\provider\providers\interfaces\create_embedding;
 use local_mxaimanager\app\ai\provider\providers\interfaces\create_image;
+use local_mxaimanager\app\exceptions\invalid_provider_instance_configuration;
 use local_mxaimanager\app\exceptions\invalid_provider_instance_response;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -767,10 +769,13 @@ class openai_test extends \base_testcase
     {
         $mform = $this->createMock(\MoodleQuickForm::class);
 
-        // Expectations for all the element additions
-        $mform->expects($this->exactly(6))->method('addElement');
-        $mform->expects($this->exactly(6))->method('setType');
-        $mform->expects($this->exactly(2))->method('setDefault');
+        // 6 existing fields (base_url, api_key, chat_model, embedding_model, image_model,
+        // transcription_model) + 3 new TTS fields (tts_model, tts_voice, tts_format).
+        $mform->expects($this->exactly(9))->method('addElement');
+        // setType is called only on text fields, not on selects — TTS adds 1 text + 2 selects.
+        $mform->expects($this->exactly(7))->method('setType');
+        // setDefault was called for base_url + api_key; TTS adds defaults for voice and format.
+        $mform->expects($this->exactly(4))->method('setDefault');
 
         $element_name_prefix = 'test_';
 
@@ -791,7 +796,8 @@ class openai_test extends \base_testcase
             'prefix_chat_model' => 'gpt-3.5-turbo',
             'prefix_embedding_model' => 'text-embedding-ada-002',
             'prefix_image_model' => 'some-image-model',
-            'prefix_transcription_model' => 'whisper-1'
+            'prefix_transcription_model' => 'whisper-1',
+            'prefix_tts_model' => 'tts-1'
         ];
 
         $errors = \local_mxaimanager\app\ai\provider\providers\openai::moodleform_validation(
@@ -913,6 +919,27 @@ class openai_test extends \base_testcase
         $this->assertNotEmpty($errors['prefix_transcription_model']);
     }
 
+    public function test_moodleform_validation_missing_tts_model(): void
+    {
+        $data = [
+            'prefix_base_url' => 'https://api.openai.com',
+            'prefix_api_key' => 'test_key',
+            'prefix_chat_model' => 'gpt-3.5-turbo',
+            'prefix_embedding_model' => 'text-embedding-ada-002',
+            'prefix_image_model' => 'some-image-model',
+            'prefix_transcription_model' => 'whisper-1'
+        ];
+
+        $errors = \local_mxaimanager\app\ai\provider\providers\openai::moodleform_validation(
+            $data,
+            'prefix_'
+        );
+
+        $this->assertArrayHasKey('prefix_tts_model', $errors);
+        $this->assertIsString($errors['prefix_tts_model']);
+        $this->assertNotEmpty($errors['prefix_tts_model']);
+    }
+
     public function test_action_moodleform_definition_chat_completion(): void
     {
         $mform = $this->createMock(\MoodleQuickForm::class);
@@ -1006,5 +1033,250 @@ class openai_test extends \base_testcase
 
         // The static method was called successfully if no exception was thrown
         $this->assertTrue(true);
+    }
+
+    public function test_action_moodleform_definition_create_audio(): void
+    {
+        $mform = $this->createMock(\MoodleQuickForm::class);
+
+        // TTS adds 3 elements: tts_model (text + setType) and tts_voice/tts_format (selects + setDefault).
+        $mform->expects($this->exactly(3))->method('addElement');
+        $mform->expects($this->once())->method('setType');
+        $mform->expects($this->exactly(2))->method('setDefault');
+
+        $element_name_prefix = 'test_';
+
+        \local_mxaimanager\app\ai\provider\providers\openai::action_moodleform_definition(
+            $mform,
+            create_audio::class,
+            $element_name_prefix
+        );
+
+        // The static method was called successfully if no exception was thrown
+        $this->assertTrue(true);
+    }
+
+    public function test_create_audio_success(): void
+    {
+        $json_config = [
+            'base_url' => 'https://api.openai.com',
+            'api_key' => 'test_key',
+            'chat_model' => 'gpt-3.5-turbo',
+            'embedding_model' => 'text-embedding-ada-002',
+            'image_model' => 'dall-e-3',
+            'transcription_model' => 'whisper-1',
+            'tts_model' => 'tts-1',
+            'tts_voice' => 'nova',
+            'tts_format' => 'mp3'
+        ];
+
+        $raw_audio = 'binary-audio-bytes';
+
+        $this->mock_curl->expects($this->once())
+            ->method('post')
+            ->with(
+                'https://api.openai.com/v1/audio/speech',
+                $this->callback(function ($data) {
+                    $decoded = json_decode($data, true);
+                    return isset($decoded['model'], $decoded['input'], $decoded['voice'], $decoded['response_format']) &&
+                        $decoded['model'] === 'tts-1' &&
+                        $decoded['input'] === 'Hola mundo' &&
+                        $decoded['voice'] === 'nova' &&
+                        $decoded['response_format'] === 'mp3';
+                })
+            )
+            ->willReturn($raw_audio);
+
+        $provider = new \local_mxaimanager\app\ai\provider\providers\openai(
+            $this->mock_base_factory,
+            $json_config
+        );
+
+        $result = $provider->create_audio('Hola mundo');
+
+        $this->assertEquals(base64_encode($raw_audio), $result->get_response());
+        $this->assertEquals(0, $result->get_input_tokens());
+        $this->assertEquals(0, $result->get_output_tokens());
+    }
+
+    public function test_create_audio_uses_default_voice_and_format_when_empty(): void
+    {
+        $json_config = [
+            'base_url' => 'https://api.openai.com',
+            'api_key' => 'test_key',
+            'chat_model' => 'gpt-3.5-turbo',
+            'embedding_model' => 'text-embedding-ada-002',
+            'image_model' => 'dall-e-3',
+            'transcription_model' => 'whisper-1',
+            'tts_model' => 'tts-1'
+            // tts_voice and tts_format intentionally omitted.
+        ];
+
+        $this->mock_curl->expects($this->once())
+            ->method('post')
+            ->with(
+                'https://api.openai.com/v1/audio/speech',
+                $this->callback(function ($data) {
+                    $decoded = json_decode($data, true);
+                    return $decoded['voice'] === 'alloy' && $decoded['response_format'] === 'mp3';
+                })
+            )
+            ->willReturn('binary-audio-bytes');
+
+        $provider = new \local_mxaimanager\app\ai\provider\providers\openai(
+            $this->mock_base_factory,
+            $json_config
+        );
+
+        $result = $provider->create_audio('Test');
+
+        $this->assertNotEmpty($result->get_response());
+    }
+
+    public function test_create_audio_missing_tts_model(): void
+    {
+        $json_config = [
+            'base_url' => 'https://api.openai.com',
+            'api_key' => 'test_key',
+            'chat_model' => 'gpt-3.5-turbo',
+            'embedding_model' => 'text-embedding-ada-002'
+        ];
+
+        $provider = new \local_mxaimanager\app\ai\provider\providers\openai(
+            $this->mock_base_factory,
+            $json_config
+        );
+
+        $this->expectException(invalid_provider_instance_configuration::class);
+        $this->expectExceptionMessage('TTS model is not configured');
+
+        $provider->create_audio('Hello');
+    }
+
+    public function test_create_audio_invalid_voice(): void
+    {
+        $json_config = [
+            'base_url' => 'https://api.openai.com',
+            'api_key' => 'test_key',
+            'chat_model' => 'gpt-3.5-turbo',
+            'embedding_model' => 'text-embedding-ada-002',
+            'tts_model' => 'tts-1',
+            'tts_voice' => 'not-a-real-voice',
+            'tts_format' => 'mp3'
+        ];
+
+        $provider = new \local_mxaimanager\app\ai\provider\providers\openai(
+            $this->mock_base_factory,
+            $json_config
+        );
+
+        $this->expectException(invalid_provider_instance_configuration::class);
+        $this->expectExceptionMessage('TTS voice "not-a-real-voice" is not supported by OpenAI');
+
+        $provider->create_audio('Hello');
+    }
+
+    public function test_create_audio_invalid_format(): void
+    {
+        $json_config = [
+            'base_url' => 'https://api.openai.com',
+            'api_key' => 'test_key',
+            'chat_model' => 'gpt-3.5-turbo',
+            'embedding_model' => 'text-embedding-ada-002',
+            'tts_model' => 'tts-1',
+            'tts_voice' => 'alloy',
+            'tts_format' => 'ogg-vorbis'
+        ];
+
+        $provider = new \local_mxaimanager\app\ai\provider\providers\openai(
+            $this->mock_base_factory,
+            $json_config
+        );
+
+        $this->expectException(invalid_provider_instance_configuration::class);
+        $this->expectExceptionMessage('TTS format "ogg-vorbis" is not supported by OpenAI');
+
+        $provider->create_audio('Hello');
+    }
+
+    public function test_create_audio_curl_error(): void
+    {
+        $json_config = [
+            'base_url' => 'https://api.openai.com',
+            'api_key' => 'test_key',
+            'chat_model' => 'gpt-3.5-turbo',
+            'embedding_model' => 'text-embedding-ada-002',
+            'tts_model' => 'tts-1',
+            'tts_voice' => 'alloy',
+            'tts_format' => 'mp3'
+        ];
+
+        $this->mock_curl->expects($this->once())
+            ->method('post')
+            ->will($this->throwException(new \Exception('Connection failed')));
+
+        $provider = new \local_mxaimanager\app\ai\provider\providers\openai(
+            $this->mock_base_factory,
+            $json_config
+        );
+
+        $this->expectException(invalid_provider_instance_response::class);
+        $this->expectExceptionMessage('Connection failed');
+
+        $provider->create_audio('Hello');
+    }
+
+    public function test_create_audio_api_error_response(): void
+    {
+        $json_config = [
+            'base_url' => 'https://api.openai.com',
+            'api_key' => 'test_key',
+            'chat_model' => 'gpt-3.5-turbo',
+            'embedding_model' => 'text-embedding-ada-002',
+            'tts_model' => 'tts-1',
+            'tts_voice' => 'alloy',
+            'tts_format' => 'mp3'
+        ];
+
+        $this->mock_curl->expects($this->once())
+            ->method('post')
+            ->willReturn('{"error":{"message":"Invalid API key","type":"invalid_request_error"}}');
+
+        $provider = new \local_mxaimanager\app\ai\provider\providers\openai(
+            $this->mock_base_factory,
+            $json_config
+        );
+
+        $this->expectException(invalid_provider_instance_response::class);
+        $this->expectExceptionMessage('OpenAI TTS error');
+
+        $provider->create_audio('Hello');
+    }
+
+    public function test_create_audio_empty_response(): void
+    {
+        $json_config = [
+            'base_url' => 'https://api.openai.com',
+            'api_key' => 'test_key',
+            'chat_model' => 'gpt-3.5-turbo',
+            'embedding_model' => 'text-embedding-ada-002',
+            'tts_model' => 'tts-1',
+            'tts_voice' => 'alloy',
+            'tts_format' => 'mp3'
+        ];
+
+        $this->mock_curl->expects($this->once())
+            ->method('post')
+            ->willReturn('');
+
+        $provider = new \local_mxaimanager\app\ai\provider\providers\openai(
+            $this->mock_base_factory,
+            $json_config
+        );
+
+        $this->expectException(invalid_provider_instance_response::class);
+        $this->expectExceptionMessage('Empty audio response from OpenAI TTS');
+
+        $provider->create_audio('Hello');
     }
 }

--- a/tests/unit/app/ai/provider/providers/openai_test.php
+++ b/tests/unit/app/ai/provider/providers/openai_test.php
@@ -389,7 +389,7 @@ class openai_test extends \base_testcase
         $this->assertEquals('{"name": "John"}', $result->get_response());
     }
 
-    public function test_create_image_success_url(): void
+    public function test_create_image_url_not_supported(): void
     {
         $json_config = [
             'base_url' => 'https://api.openai.com',
@@ -399,30 +399,20 @@ class openai_test extends \base_testcase
             'image_model' => 'dall-e-3'
         ];
 
-        $expected_response = '{"data":[{"url":"https://example.com/image.png"}]}';
-
-        $this->mock_curl->expects($this->once())
-            ->method('post')
-            ->with(
-                'https://api.openai.com/v1/images/generations',
-                $this->callback(function ($data) {
-                    $decoded = json_decode($data, true);
-                    return isset($decoded['model'], $decoded['prompt'], $decoded['response_format']) &&
-                        $decoded['model'] === 'dall-e-3' &&
-                        $decoded['prompt'] === 'A test image' &&
-                        $decoded['response_format'] === 'url';
-                })
-            )
-            ->willReturn($expected_response);
+        // The new OpenAI image API only returns base64, so requesting a URL (return_b64 = false)
+        // is no longer supported and must fail before any request is made.
+        $this->mock_curl->expects($this->never())
+            ->method('post');
 
         $provider = new \local_mxaimanager\app\ai\provider\providers\openai(
             $this->mock_base_factory,
             $json_config
         );
 
-        $result = $provider->create_image('A test image', false);
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('Openai new API only accepts b64_json');
 
-        $this->assertEquals('https://example.com/image.png', $result->get_response());
+        $provider->create_image('A test image', false);
     }
 
     public function test_create_image_success_b64(): void
@@ -432,21 +422,23 @@ class openai_test extends \base_testcase
             'api_key' => 'test_key',
             'chat_model' => 'gpt-3.5-turbo',
             'embedding_model' => 'text-embedding-ada-002',
-            'image_model' => 'dall-e-3'
+            'image_model' => 'gpt-image-1',
         ];
 
         $expected_response = '{"data":[{"b64_json":"base64encodedimage"}]}';
 
+        // The OpenAI /v1/images/generations endpoint no longer accepts response_format, so the
+        // provider must send only model and prompt and always read b64_json from the response.
         $this->mock_curl->expects($this->once())
             ->method('post')
             ->with(
                 'https://api.openai.com/v1/images/generations',
                 $this->callback(function ($data) {
                     $decoded = json_decode($data, true);
-                    return isset($decoded['model'], $decoded['prompt'], $decoded['response_format']) &&
-                        $decoded['model'] === 'dall-e-3' &&
-                        $decoded['prompt'] === 'A test image' &&
-                        $decoded['response_format'] === 'b64_json';
+                    return isset($decoded['model'], $decoded['prompt']) &&
+                        !isset($decoded['response_format']) &&
+                        $decoded['model'] === 'gpt-image-1' &&
+                        $decoded['prompt'] === 'A test image';
                 })
             )
             ->willReturn($expected_response);
@@ -503,7 +495,7 @@ class openai_test extends \base_testcase
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Connection failed');
 
-        $provider->create_image('A test image', false);
+        $provider->create_image('A test image', true);
     }
 
     public function test_create_image_invalid_response(): void
@@ -527,7 +519,7 @@ class openai_test extends \base_testcase
 
         $this->expectException(invalid_provider_instance_response::class);
 
-        $provider->create_image('A test image', false);
+        $provider->create_image('A test image', true);
     }
 
     public function test_get_embedding_success(): void

--- a/version.php
+++ b/version.php
@@ -6,7 +6,7 @@ defined('MOODLE_INTERNAL') || die();
 
 /** @var object $plugin */
 $plugin->component = 'local_mxaimanager';
-$plugin->version = 2026040700;
+$plugin->version = 2026052900;
 $plugin->requires = 2025041400; // Requires Moodle 5.0
-$plugin->release = '1.0.5 (Build: 2026-04-07)';
+$plugin->release = '1.1.0 (Build: 2026-05-29)';
 $plugin->dependencies = [];

--- a/version.php
+++ b/version.php
@@ -6,7 +6,7 @@ defined('MOODLE_INTERNAL') || die();
 
 /** @var object $plugin */
 $plugin->component = 'local_mxaimanager';
-$plugin->version = 2026040700;
+$plugin->version = 2026052700;
 $plugin->requires = 2025041400; // Requires Moodle 5.0
 $plugin->release = '1.0.5 (Build: 2026-04-07)';
 $plugin->dependencies = [];


### PR DESCRIPTION
OpenAI api has changed and dall-e-XXX models have been deprecated. Changes are made to be compatible with tiny_courseaiimages.
Also a new feture has been created to be able to use tiny_courseaiaudios subplugin.
