### PR TITLE
Added a utility function that merges outgoing system role messages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,42 +1,28 @@
-name: Integration & Unit test
+name: Moodle CI
 
 on:
   pull_request:
     branches:
+      - main
+      - master
       - MOODLE_*_STABLE
+  push:
+    branches:
+      - main
+      - master
+      - MOODLE_*_STABLE
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  actions: read
+  pull-requests: write
+  issues: write
+  statuses: write
 
 jobs:
-  PHPUnit:
-    runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.experimental }}
-    strategy:
-      matrix:
-        php: [8.2, 8.3, 8.4]
-        os: [ubuntu-latest]
-        moodle: [MOODLE_500_STABLE,MOODLE_502_STABLE]
-        dbtype: [mysqli, sqlsrv]
-        experimental: [false]
-        exclude:
-          - php: 8.2
-            os: ubuntu-latest
-            moodle: MOODLE_502_STABLE
-            dbtype: sqlsrv
-            experimental: false
-          - php: 8.2
-            os: ubuntu-latest
-            moodle: MOODLE_502_STABLE
-            dbtype: mysqli
-            experimental: false
-    steps:
-      - name: Unit testing & integration testing
-        uses: praxisdigital/moodle-test-action@master
-        with:
-          plugin: local_mxaimanager
-          plugin-path: local/mxaimanager
-          os: ${{ matrix.os }}
-          php: ${{ matrix.php }}
-          dbtype: ${{ matrix.dbtype }}
-          moodle: ${{ matrix.moodle }}
-          experimental: ${{ matrix.experimental }}
-          dependencies: ${{ matrix.dependencies }}
-          PRIVATE_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  ci:
+    uses: praxisdigital/moodle-test-action/.github/workflows/ci.yml@master
+    secrets: inherit

--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ None
 
 ## Change log
 
+* **1.0.6 (2026081100)**
+    - Fixed bug with providers using chat completion and sending multiple system role messages in the messages array
 * **1.0.5 (2026040700)**
     - Removed support for text-to-image generation in nebius AI provider.
 * **1.0.4 (2026011200)**

--- a/classes/app/ai/provider/providers/interfaces/chat_completion.php
+++ b/classes/app/ai/provider/providers/interfaces/chat_completion.php
@@ -27,4 +27,5 @@ interface chat_completion
         bool $json_mode = false,
         ?array $json_schema = null
     ): chat_completion_request;
+
 }

--- a/classes/app/ai/provider/providers/mistral.php
+++ b/classes/app/ai/provider/providers/mistral.php
@@ -176,6 +176,8 @@ class mistral extends provider implements interfaces\chat_completion, interfaces
             throw new invalid_provider_instance_configuration('Chat model is not configured');
         }
 
+        $messages = $this->merge_system_messages($messages);
+
         $payload = [
             'model' => $this->chat_model,
             'messages' => $messages,

--- a/classes/app/ai/provider/providers/nebius.php
+++ b/classes/app/ai/provider/providers/nebius.php
@@ -143,6 +143,8 @@ class nebius extends provider implements interfaces\chat_completion, interfaces\
             throw new invalid_provider_instance_configuration('Chat model is not configured');
         }
 
+        $messages = $this->merge_system_messages($messages);
+
         $payload = [
             'model' => $this->chat_model,
             'messages' => $messages,
@@ -163,6 +165,7 @@ class nebius extends provider implements interfaces\chat_completion, interfaces\
         }
 
         try {
+
             $response = $this->curl->post(
                 "{$this->base_url}/v1/chat/completions",
                 json_encode($payload, JSON_THROW_ON_ERROR)

--- a/classes/app/ai/provider/providers/ollama.php
+++ b/classes/app/ai/provider/providers/ollama.php
@@ -143,6 +143,8 @@ class ollama extends provider implements interfaces\chat_completion, interfaces\
             throw new invalid_provider_instance_configuration('Chat model is not configured');
         }
 
+        $messages = $this->merge_system_messages($messages);
+
         $payload = [
             'model' => $this->chat_model,
             'stream' => false,

--- a/classes/app/ai/provider/providers/openai.php
+++ b/classes/app/ai/provider/providers/openai.php
@@ -276,6 +276,8 @@ class openai extends provider implements interfaces\chat_completion, interfaces\
             throw new invalid_provider_instance_configuration('Chat model is not configured');
         }
 
+        $messages = $this->merge_system_messages($messages);
+
         $payload = [
             'model' => $this->chat_model,
             'messages' => $messages,

--- a/classes/app/ai/provider/providers/provider.php
+++ b/classes/app/ai/provider/providers/provider.php
@@ -8,6 +8,7 @@ defined('MOODLE_INTERNAL') || die();
 
 // @codeCoverageIgnoreEnd
 
+use local_mxaimanager\app\ai\provider\message;
 use local_mxaimanager\app\factory as base_factory;
 
 abstract class provider
@@ -61,4 +62,28 @@ abstract class provider
     {
         return str_replace(' ', '_', strtolower(static::class)) . '_';
     }
+
+
+    /**
+     * Merges the contents of all system messages into one and places it at index zero.
+     *
+     * @param message[] $messages
+     * @return message[]
+     */
+    protected function merge_system_messages(array $messages): array
+    {
+        $system_messages_contents = [];
+        $non_system_messages = [];
+
+        foreach ($messages as $message) {
+            if ($message->get_role() === 'system') {
+                $system_messages_contents[] = $message->get_content();
+            } else {
+                $non_system_messages[] = $message;
+            }
+        }
+
+        return array_merge([new message('system', implode("\n", $system_messages_contents))], $non_system_messages);
+    }
+
 }

--- a/classes/app/ai/provider/providers/provider.php
+++ b/classes/app/ai/provider/providers/provider.php
@@ -76,11 +76,21 @@ abstract class provider
         $non_system_messages = [];
 
         foreach ($messages as $message) {
-            if ($message->get_role() === 'system') {
-                $system_messages_contents[] = $message->get_content();
-            } else {
-                $non_system_messages[] = $message;
+            $msg = $message;
+            //Guard against message delivered as associative array instead of obj of type message.
+            if(is_array($message)) {
+                $msg = new message($message['role'], $message['content']);
             }
+
+            if ($msg->get_role() === 'system') {
+                $system_messages_contents[] = $msg->get_content();
+            } else {
+                $non_system_messages[] = $msg;
+            }
+        }
+
+        if(empty($system_messages_contents)) {
+            return $messages;
         }
 
         return array_merge([new message('system', implode("\n", $system_messages_contents))], $non_system_messages);

--- a/tests/unit/app/ai/provider/providers/provider_test.php
+++ b/tests/unit/app/ai/provider/providers/provider_test.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace local_mxaimanager\unit\app\ai\provider\providers;
+
+// @codeCoverageIgnoreStart
+defined('MOODLE_INTERNAL') || die();
+
+// @codeCoverageIgnoreEnd
+
+use local_mxaimanager\app\ai\provider\message;
+use local_mxaimanager\app\ai\provider\providers\provider;
+use local_mxaimanager\app\factory as base_factory;
+use ReflectionMethod;
+
+class provider_test extends \base_testcase
+{
+    private provider $provider;
+
+    protected function setUp(): void
+    {
+        $this->provider = new class ($this->createMock(base_factory::class), []) extends provider {
+            public function __construct(base_factory $base_factory, array $json_config)
+            {
+                $this->base_factory = $base_factory;
+            }
+
+            public static function moodleform_definition(\MoodleQuickForm $mform, string $element_name_prefix): void
+            {
+            }
+
+            public static function moodleform_validation(array $data, string $element_name_prefix): array
+            {
+                return [];
+            }
+
+            public static function action_moodleform_definition(
+                \MoodleQuickForm $mform,
+                string $interface,
+                string $element_name_prefix
+            ): void {
+            }
+        };
+    }
+
+    /**
+     * @param message[] $messages
+     * @return message[]
+     */
+    private function call_merge_system_messages(array $messages): array
+    {
+        $method = new ReflectionMethod(provider::class, 'merge_system_messages');
+        $method->setAccessible(true);
+
+        return $method->invoke($this->provider, $messages);
+    }
+
+    public function test_merge_system_messages_single_system_already_at_index_zero(): void
+    {
+        $messages = [
+            new message('system', 'You are a helpful assistant.'),
+            new message('user', 'Hello'),
+            new message('assistant', 'Hi there'),
+        ];
+
+        $result = $this->call_merge_system_messages($messages);
+
+        $this->assertCount(3, $result);
+        $this->assertSame('system', $result[0]->get_role());
+        $this->assertSame('You are a helpful assistant.', $result[0]->get_content());
+        $this->assertSame('user', $result[1]->get_role());
+        $this->assertSame('Hello', $result[1]->get_content());
+        $this->assertSame('assistant', $result[2]->get_role());
+        $this->assertSame('Hi there', $result[2]->get_content());
+    }
+
+    public function test_merge_system_messages_system_messages_at_bottom(): void
+    {
+        $messages = [
+            new message('user', 'First user message'),
+            new message('assistant', 'First reply'),
+            new message('user', 'Second user message'),
+            new message('system', 'System instruction A'),
+            new message('system', 'System instruction B'),
+        ];
+
+        $result = $this->call_merge_system_messages($messages);
+
+        $this->assertCount(4, $result);
+        $this->assertSame('system', $result[0]->get_role());
+        $this->assertSame("System instruction A\nSystem instruction B", $result[0]->get_content());
+        $this->assertSame('user', $result[1]->get_role());
+        $this->assertSame('First user message', $result[1]->get_content());
+        $this->assertSame('assistant', $result[2]->get_role());
+        $this->assertSame('First reply', $result[2]->get_content());
+        $this->assertSame('user', $result[3]->get_role());
+        $this->assertSame('Second user message', $result[3]->get_content());
+    }
+
+    public function test_merge_system_messages_system_messages_spread_throughout(): void
+    {
+        $messages = [
+            new message('system', 'Preamble'),
+            new message('user', 'Question one'),
+            new message('system', 'Middle rule'),
+            new message('assistant', 'Answer one'),
+            new message('user', 'Question two'),
+            new message('system', 'Closing rule'),
+        ];
+
+        $result = $this->call_merge_system_messages($messages);
+
+        $this->assertCount(4, $result);
+        $this->assertSame('system', $result[0]->get_role());
+        $this->assertSame("Preamble\nMiddle rule\nClosing rule", $result[0]->get_content());
+        $this->assertSame('user', $result[1]->get_role());
+        $this->assertSame('Question one', $result[1]->get_content());
+        $this->assertSame('assistant', $result[2]->get_role());
+        $this->assertSame('Answer one', $result[2]->get_content());
+        $this->assertSame('user', $result[3]->get_role());
+        $this->assertSame('Question two', $result[3]->get_content());
+    }
+}

--- a/version.php
+++ b/version.php
@@ -6,7 +6,7 @@ defined('MOODLE_INTERNAL') || die();
 
 /** @var object $plugin */
 $plugin->component = 'local_mxaimanager';
-$plugin->version = 2026061800;
+$plugin->version = 2026081100;
 $plugin->requires = 2025041400; // Requires Moodle 5.0
-$plugin->release = '1.1.0 (Build: 2026-05-29)';
+$plugin->release = '1.0.6 (Build: 2026-08-11)';
 $plugin->dependencies = [];


### PR DESCRIPTION
Some AI-providers like Nebius has changed their API and made it forbidden for clients to:
- Send a messages array with more than 1 system role message
- Send a messages array where the system role message is not placed at index 0

I have solved this by creating a function that merges them and places them at index 0.
Unit tests included.